### PR TITLE
Add gulpfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 *.log
 .idea/
+production/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,30 @@
+var gulp = require('gulp');
+var cssmin = require('gulp-cssmin');
+var uglify = require('gulp-uglify');
+var nodemon = require('gulp-nodemon');
+var gif = require('gulp-if');
+
+var inProduction = process.env['NODE_ENV'] == 'production';
+
+gulp.task('asset-css', function() {
+  gulp.src('assets/css/main.css')
+    .pipe(gif(inProduction, cssmin()))
+    .pipe(gulp.dest('production/css'));
+});
+
+
+gulp.task('asset-js', function() {
+  gulp.src('assets/js/*')
+    .pipe(gif(inProduction, uglify()))
+    .pipe(gulp.dest('production/js'));
+});
+
+gulp.task('build', ['asset-css', 'asset-js']);
+
+gulp.task('watch-app', function() {
+  nodemon({
+    script: 'app.js',
+    ext: 'js json',
+    env: {'NODE_ENV': 'development'}
+  });
+});

--- a/package.json
+++ b/package.json
@@ -23,5 +23,12 @@
   "bugs": {
     "url": "https://github.com/Cryptkeeper/Minetrack/issues"
   },
-  "homepage": "https://github.com/Cryptkeeper/Minetrack#README"
+  "homepage": "https://github.com/Cryptkeeper/Minetrack#README",
+  "devDependencies": {
+    "gulp": "^3.9.0",
+    "gulp-cssmin": "^0.1.7",
+    "gulp-if": "^2.0.0",
+    "gulp-nodemon": "^2.0.4",
+    "gulp-uglify": "^1.5.1"
+  }
 }


### PR DESCRIPTION
This helps make development much easier.

At the moment, the following tasks are available:

* `build`: runs `asset-css` and `asset-js`.
* `asset-css` and `asset-js`: generates minified CSS/JS files into `production/`.
* `watch-app`: uses [gulp-nodemon](https://www.npmjs.com/package/gulp-nodemon) to watch all `js` and `json` files and restart `app.js` when they change.