### PR TITLE
Tidy up Webserver

### DIFF
--- a/config.json
+++ b/config.json
@@ -152,9 +152,9 @@
 		}
 	],
 	"faviconOverride": {
-		"Hypixel PE": "/favicons/hypixelpe.png",
-		"Lifeboat": "/favicons/lifeboat.png",
-		"Mineplex": "/favicons/mineplex.png"
+		"Hypixel PE": "/images/favicons/hypixelpe.png",
+		"Lifeboat": "/images/favicons/lifeboat.png",
+		"Mineplex": "/images/favicons/mineplex.png"
 	},
 	"site": {
 		"port": 80,

--- a/config.json
+++ b/config.json
@@ -151,16 +151,6 @@
 			"type": "PC"
 		}
 	],
-	"routes": {
-		"/": "assets/html/index.html",
-		"/images/compass.png": "assets/images/compass.png",
-		"/js/site.js": "assets/js/site.js",
-		"/js/util.js": "assets/js/util.js",
-		"/css/main.css": "assets/css/main.css",
-		"/favicons/hypixelpe.png": "assets/images/favicons/hypixelpe.png",
-		"/favicons/lifeboat.png": "assets/images/favicons/lifeboat.png",
-		"/favicons/mineplex.png": "assets/images/favicons/mineplex.png"
-	},
 	"faviconOverride": {
 		"Hypixel PE": "/favicons/hypixelpe.png",
 		"Lifeboat": "/favicons/lifeboat.png",

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,6 +20,7 @@ module.exports = {
 			}
 			var address = self.server.address();
 			logger.log('info', 'Started on %s:%d', address.address, address.port);
+			return callback();
 		});
 
 		// pass express and socket io to it

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,60 +1,49 @@
-var http = require('http');
-var fs = require('fs');
-var url = require('url');
-var mime = require('mime');
-var io = require('socket.io');
+var http = require('http'),
+	express = require('express'),
+	io = require('socket.io');
 
 var logger = require('./logger');
 
 var config = require('../config.json');
 
-exports.start = function(callback) {
-	var urlMapping = [];
-	var routeKeys = Object.keys(config.routes);
+module.exports = {
+	server: null,
+	app: null,
+	io: null,
+	start: function(callback){
+		var self = this;
+		// setup basic server
+		self.server = http.createServer();
+		self.server.listen(config.site.port, config.site.ip, function(err){
+			if(err){
+				return callback(err);
+			}
+			var address = self.server.address();
+			logger.log('info', 'Started on %s:%d', address.address, address.port);
+		});
 
-	// Map the (static) routes from our config.
-	for (var i = 0; i < routeKeys.length; i++) {
-		urlMapping[routeKeys[i]] = config.routes[routeKeys[i]];
+		// pass express and socket io to it
+		self.app = express();
+		self.server.on('request', self.app);
+		self.io = io.listen(self.server);
+
+		// configure express to do some heavy lifting
+		self.app.use(express.static('./assets'));
+
+		// in the future we might use the template system rather than sending html files :)
+		self.app.all('/', function(req, res){
+			res.sendFile('html/index.html', {
+				root: './assets'
+			}, function(err){
+				if(err){
+					res.status(500).end('Failed to find index file!')
+					logger.log('error', err);
+				}
+			});
+		});
+
+		self.app.use(function(req, res, next){
+			res.status(404).end('404');
+		});
 	}
-
-	logger.log('info', Object.keys(config.routes));
-
-	// Create our tiny little HTTP server.
-	var server = http.createServer(function(req, res) {
-		var requestUrl = url.parse(req.url).pathname;
-
-		logger.log('info', '%s requested: %s', req.connection.remoteAddress, requestUrl);
-
-		if (requestUrl === '/status.json') {
-			res.setHeader('Content-Type', 'text/plain');
-			res.write(JSON.stringify({
-				error: true,
-				message: 'API deprecated.'
-			}));
-
-			res.end();
-		} else if (requestUrl in urlMapping) {
-			var file = urlMapping[requestUrl];
-
-			res.setHeader('Content-Type', mime.lookup(file));
-			
-			fs.createReadStream(file).pipe(res);
-		} else {
-			res.statusCode = 404;
-			res.write('404');
-
-			res.end();
-		}
-	});
-
-	server.listen(config.site.port, config.site.ip);
-
-	// I don't like this. But it works, I think.
-	io = io.listen(server);
-	exports.io = io;
-
-	// Since everything is loaded, do some final prep work.
-	logger.log('info', 'Started on %s:%d', config.site.ip, config.site.port);
-
-	callback();
-};
+}

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "A Minecraft server tracker that lets you focus on the basics.",
   "main": "app.js",
   "dependencies": {
+    "express": "4.13.3",
     "mc-ping-updated": "0.0.7",
     "mcpe-ping": "0.0.3",
-    "mime": "^1.3.4",
-    "request": "^2.65.0",
-    "socket.io": "^1.3.7",
-    "winston": "^2.0.0"
+    "request": "2.65.0",
+    "socket.io": "1.3.7",
+    "winston": "2.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This replaces the need to keep a config file to map the assets folder to
the public server. You might consider replacing static html files with an actual template parser with express.

I also removed `mime`, that you you were using to send the files with a raw http server.

Additionally I've cleaned up the "^v.v.v" notation on your `package.json` file so future developers won't have version dependency problems.

This also corrects the exports behavior where you are mounting `io` to exports. It's best to use `module.exports` when creating objects you plan on returning.