### PR TITLE
Remove vikkcraft

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -120,11 +120,6 @@
 		"type": "PC"
 	},
 	{
-		"name": "VikkCraft",
-		"ip": "hub.vikkcraft.com",
-		"type": "PC"
-	},
-	{
 		"name": "MCMagic",
 		"ip": "mcmagic.us",
 		"type": "PC"


### PR DESCRIPTION
Vikkcraft and ArkhamNetwork were merged recently, which means they are now duplicates of each other on "minetrack.me". So this pull request resolves that.

And below are forum posts showing that they merged.
http://arkhamnetwork.org/community/threads/network-merge-information.33816/
https://vikkcraft.com/threads/important-update-vikkcrafts-future.24239/