### PR TITLE
Show supported versions for PC servers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 production/
 database.sql
 database.sql-journal
+.DS_Store
+

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,16 +1,16 @@
 @import url(https://fonts.googleapis.com/css?family=Open+Sans:700,300,400);
 
 * {
-	margin: 0;
-	padding: 0;
+    margin: 0;
+    padding: 0;
 }
 
 body {
-	background: #3B3738;
-	color: #FFF;
-	font-family: "Open Sans", sans-serif;
-	font-size: 18px;
-	font-weight: 300 !important;
+    background: #3B3738;
+    color: #FFF;
+    font-family: "Open Sans", sans-serif;
+    font-size: 18px;
+    font-weight: 300 !important;
 }
 
 /* Page layout */
@@ -158,12 +158,12 @@ a {
 }
 
 .server > .column > .versions {
-	min-height: 22px;
-	padding-bottom: 3px;
+    min-height: 22px;
+    padding-bottom: 3px;
 }
 
 .server > .column > .versions > .version {
-	padding: 1px 5px;
+    padding: 1px 5px;
     border-radius: 2px;
     border: 1px solid #A09E9E;
     font-size: 12px;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -145,7 +145,7 @@ a {
 }
 
 .server > .column > .rank {
-    width: 64px; 
+    width: 64px;
     padding-top: 3px;
 }
 
@@ -155,6 +155,18 @@ a {
     border: 1px solid #A09E9E;
     font-size: 14px;
     margin-bottom: 2px;
+}
+
+.server > .column > .versions {
+	min-height: 22px;
+	padding-bottom: 3px;
+}
+
+.server > .column > .versions > .version {
+	padding: 1px 5px;
+    border-radius: 2px;
+    border: 1px solid #A09E9E;
+    font-size: 12px;
 }
 
 .category-header {

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -5,6 +5,15 @@ var historyPlot;
 var displayedGraphData;
 var hiddenGraphData = [];
 
+var mcVersions = {
+    'PC': {
+        4: '1.7.2',
+        5: '1.7.10',
+        47: '1.8',
+        107: '1.9'
+    }
+};
+
 var isConnected = false;
 
 var mojangServicesUpdater;
@@ -13,10 +22,21 @@ var sortServersTask;
 function updateServerStatus(lastEntry) {
     var info = lastEntry.info;
     var div = $('#status_' + safeName(info.name));
+    var versionDiv = $('#version_' + safeName(info.name));
+
+    if (lastEntry.versions) {
+        var versions = '';
+        for (var i = 0; i < lastEntry.versions.length; i++) {
+            versions += '<span class="version">' + mcVersions[lastEntry.info.type][lastEntry.versions[i]] + '</span>&nbsp;';
+        }
+        versionDiv.html(versions);
+    } else {
+        versionDiv.html('');
+    }
 
     if (lastEntry.result) {
         var result = lastEntry.result;
-        var newStatus = '<br />Players: ' + formatNumber(result.players.online);
+        var newStatus = 'Players: ' + formatNumber(result.players.online);
 
         var listing = graphs[lastEntry.info.name].listing;
 
@@ -36,7 +56,7 @@ function updateServerStatus(lastEntry) {
 
         div.html(newStatus);
     } else {
-        var newStatus = '<br /><span class="color-red">';
+        var newStatus = '<span class="color-red">';
 
         if (findErrorMessage(lastEntry.error)) {
             newStatus += findErrorMessage(lastEntry.error);
@@ -328,7 +348,7 @@ $(document).ready(function() {
                         <div class="column" style="width: 220px;">\
                             <h3>' + info.name + '&nbsp;<span class="type">' + info.type + '</span></h3>\
                             <span class="color-gray">' + info.ip + '</span>\
-                            <br />\
+                            <div id="version_' + safeName(info.name) + '" class="versions"></div>\
                             <span id="status_' + safeName(info.name) + '">Waiting</span>\
                         </div>\
                         <div class="column" style="float: right;">\

--- a/config.json
+++ b/config.json
@@ -31,5 +31,16 @@
 		"minigames": "Minigame Networks",
 		"pocket": "Pocket Edition Networks"
 	},
+	"versions": {
+		"PC": [
+			4,
+			5,
+			47,
+			107
+		],
+		"PE": [
+			0
+		]
+	},
 	"categoriesVisible": true
 }

--- a/lib/ping.js
+++ b/lib/ping.js
@@ -4,7 +4,7 @@ var mcpc_ping = require('mc-ping-updated');
 var util = require('./util');
 
 // This is a wrapper function for mc-ping-updated, mainly used to convert the data structure of the result.
-function pingMinecraftPC(host, port, timeout, callback) {
+function pingMinecraftPC(host, port, timeout, callback, version) {
     var startTime = util.getCurrentTimeMs();
 
 	mcpc_ping(host, port, function(err, res) {
@@ -22,7 +22,7 @@ function pingMinecraftPC(host, port, timeout, callback) {
 				favicon: res.favicon
 			});
 	    }
-	}, timeout);
+	}, timeout, version);
 }
 
 // This is a wrapper function for mcpe-ping, mainly used to convert the data structure of the result.
@@ -46,9 +46,9 @@ function pingMinecraftPE(host, port, timeout, callback) {
 	}, timeout);
 }
 
-exports.ping = function(host, port, type, timeout, callback) {
+exports.ping = function(host, port, type, timeout, callback, version) {
 	if (type === 'PC') {
-		pingMinecraftPC(host, port || 25565, timeout, callback);
+		pingMinecraftPC(host, port || 25565, timeout, callback, version);
 	} else if (type === 'PE') {
 		pingMinecraftPE(host, port || 19132, timeout, callback);
 	} else {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Minecraft server tracker that lets you focus on the basics.",
   "main": "app.js",
   "dependencies": {
-    "mc-ping-updated": "0.0.7",
+    "mc-ping-updated": "0.1.0",
     "mcpe-ping": "0.0.3",
     "mime": "^1.3.4",
     "request": "^2.65.0",


### PR DESCRIPTION
The Minetrack daemon will send a different protocol version each time it pings a server. If a server responds with the same protocol version, it is assumed that the version is supported, and it is shown on the page above the server's player count.
    
The list of versions to be tried is stored in config.json.

At the moment, 4 versions are checked:
- 4 (Minecraft 1.7.2)
- 5 (Minecraft 1.7.10)
- 47 (Minecraft 1.8)
- 107 (Minecraft 1.9)

Dependent on changes in Cryptkeeper/mc-ping-updated#1.