### PR TITLE
Fix big graph initial width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ production/
 database.sql
 database.sql-journal
 .DS_Store
-
+yarn.lock

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -196,7 +196,6 @@ h3 {
 
 /* The big graph */
 #big-graph, #big-graph-controls, #big-graph-checkboxes {
-    width: 1540px;
     margin: 15px auto 0 auto;
 }
 

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -296,9 +296,13 @@ $(document).ready(function() {
 
         createdCategories = false;
 
-        $('#big-graph').html('');
-        $('#big-graph-checkboxes').html('');
-        $('#big-graph-controls').css('display', 'none');
+        var widthCss = {width: window.innerWidth - 17};
+
+        $('#big-graph').html('').css(widthCss);
+        $('#big-graph-checkboxes').html('').css(widthCss);
+
+        widthCss['display'] = 'none';
+        $('#big-graph-controls').css(widthCss);
 
         $("#stat_totalPlayers").text(0);
         $("#stat_networks").text(0);


### PR DESCRIPTION
Currently, the #big-graph has a fixed width of 1540px.

I've made a jQuery fix where the width is set dinamically only when the graph is created.

This currently doesn't work for resize as there's a flot.js underlaying issue discussed in the beam.pro streaming later today.

Before:
![Before](http://i.imgur.com/hMotzLO.png)

After:
![After](http://i.imgur.com/ZNIrh6g.png)