### PR TITLE
Allow custom Graph colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ production/
 database.sql
 database.sql-journal
 .DS_Store
-
+yarn.lock

--- a/app.js
+++ b/app.js
@@ -26,6 +26,11 @@ function pingAll() {
 	for (var i = 0; i < servers.length; i++) {
 		// Make sure we lock our scope.
 		(function(network) {
+			// Asign auto generated color if not present
+			if (!network.color) {
+				network.color = util.stringToColor(network.name);
+			}
+
 			var attemptedVersion = config.versions[network.type][currentVersionIndex[network.type]];
 			ping.ping(network.ip, network.port, network.type, config.rates.connectTimeout, function(err, res) {
 				// Handle our ping results, if it succeeded.

--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -117,12 +117,12 @@ function convertGraphData(rawData) {
 
     var keys = Object.keys(rawData);
 
-    for (var i = 0; i < keys.length; i++) {
+    for (var i = 0; i < keys.length; i++) {    
         data.push({
             data: rawData[keys[i]],
             yaxis: 1,
             label: keys[i],
-            color: stringToColor(keys[i])
+            color: getServerColor(keys[i])
         });
     }
 

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -151,7 +151,7 @@ function updatePercentageBar() {
                     id: 'perc_bar_part_' + safeNameCopy,
                     class: 'perc-bar-part',
                     html: '',
-                    style: 'background: ' + stringToColor(server) + ';'
+                    style: 'background: ' + getServerColor(server) + ';'
                 }).appendTo(parent);
 
                 div = $('#perc_bar_part_' + safeNameCopy);

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -76,14 +76,28 @@ function getServersByCategory() {
 	return byCategory;
 }
 
-function getServerByIp(ip) {
+function getServerByField(id, value) {
 	for (var i = 0; i < publicConfig.servers.length; i++) {
 		var entry = publicConfig.servers[i];
 
-		if (entry.ip === ip) {
+		if (entry[id] === value) {
 			return entry;
 		}
 	}
+}
+
+function getServerByIp(ip) {
+	return getServerByField('ip', ip);
+}
+
+function getServerByName(name) {
+	return getServerByField('name', name);
+}
+
+function getServerColor(name) {
+	var server = getServerByName(name);
+
+	return server ? server.color : stringToColor(name);
 }
 
 // Generate (and set) the HTML that displays Mojang status.

--- a/lib/util.js
+++ b/lib/util.js
@@ -100,6 +100,18 @@ exports.getCurrentTimeMs = function() {
     return new Date().getTime();
 };
 
+exports.stringToColor = function(base) {
+    var hash;
+
+    for (var i = base.length - 1, hash = 0; i >= 0; i--) {
+        hash = base.charCodeAt(i) + ((hash << 5) - hash);
+    }
+
+    color = Math.floor(Math.abs((Math.sin(hash) * 10000) % 1 * 16777216)).toString(16);
+
+    return '#' + Array(6 - color.length + 1).join('0') + color;
+}
+
 exports.setIntervalNoDelay = function(func, delay) {
 	var task = setInterval(func, delay);
 


### PR DESCRIPTION
This fixes #75.

You can now specify a server's color adding the `"color"` key into a server in the `servers.json` file.

servers.json example:
```javascript
[
	{
		"name": "Hypixel",
		"ip": "mc.hypixel.net",
		"type": "PC",
		"category": "minigames",
                "color": "#e67e22" // Orange color
	},
	{
		"name": "HiveMC",
		"ip": "play.hivemc.com",
		"type": "PC",
		"category": "minigames"
                // No color specified, defaults to ip generated one
	}
]
```