### PR TITLE
Update sqlite3 dependency and add caret ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "dependencies": {
     "mc-ping-updated": "0.1.0",
     "mcpe-ping-fixed": "0.0.3",
-    "mime": "1.3.4",
-    "request": "2.74.0",
-    "socket.io": "1.3.7",
-    "sqlite3": "3.1.1",
-    "winston": "2.0.0"
+    "mime": "^1.3.4",
+    "request": "^2.74.0",
+    "socket.io": "^1.3.7",
+    "sqlite3": "^3.1.8",
+    "winston": "^2.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updated sqlite3 to 3.1.8 as @minecrafter said it fixed the loading problem in #82.

I added caret version ranges to big packages because there are no breaking changes in a patch update. Taken from npm: Allows changes that do not modify the left-most non-zero digit in the [major, minor, patch] tuple. In other words, this allows patch and minor updates for versions 1.0.0 and above, patch updates for versions 0.X >=0.1.0, and no updates for versions 0.0.X. [More](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004).

Additionally, a npm package-lock.json and/or a yarn.lock file should be commited to git with current working package versions.

Fixes #82 