### PR TITLE
Add link to china servers on Pocket edition page

### DIFF
--- a/assets/html/index.html
+++ b/assets/html/index.html
@@ -27,7 +27,7 @@
 
 						<img src="/images/compass.png" width="28" height="28" style="display: inline-block; margin-right: 5px;">
 						<h1 style="display: inline-block;" class="text-uppercase">Minetrack Pocket</h1>
-						<p class="subslogan text-uppercase">Watching <span id="stat_totalPlayers">0</span> players on <span id="stat_networks">0</span> networks. <a href="https://minetrack.me">View PC Servers</a>.</p>
+						<p class="subslogan text-uppercase">Watching <span id="stat_totalPlayers">0</span> players on <span id="stat_networks">0</span> networks. <a href="https://minetrack.me">View PC Servers</a> / <a href="https://china.minetrack.me">View China servers</p>
 
 					</div>
 


### PR DESCRIPTION
This change just adds the link to the china servers on the pocket edition page like it is for PC.