### PR TITLE
Adding skynetwork.com.br

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -65,6 +65,11 @@
 		"type": "PC"
 	},
 	{
+		"name": "Sky Network",
+		"ip": "skynetwork.com.br",
+		"type": "PC"
+	},
+	{
 		"name": "Hypixel China",
 		"ip": "x19hypixel.nie.netease.com",
 		"type": "PC",


### PR DESCRIPTION
Hi,

I'd like to add my server to Minetrack. Sky Network is the biggest Minecraft network and community in Brazil and I think it fits the needs to be tracked by the Minetrack website.

Thanks.