### PR TITLE
Remove Badlion Network from servers.json

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -20,11 +20,6 @@
 		"type": "PC"
 	},
 	{
-		"name": "Badlion",
-		"ip": "na.badlion.net",
-		"type": "PC"
-	},
-	{
 		"name": "Wynncraft",
 		"ip": "play.wynncraft.com",
 		"type": "PC"


### PR DESCRIPTION
Removed because the Badlion Network has closed.
![](https://i.imgur.com/QoUw5Qc.png)