### PR TITLE
Add Support for MineQuery Servers

### DIFF
--- a/config.json
+++ b/config.json
@@ -40,6 +40,9 @@
 		],
 		"PE": [
 			0
+		],
+		"MINEQUERY": [
+			0
 		]
 	},
 	"categoriesVisible": true,

--- a/lib/ping.js
+++ b/lib/ping.js
@@ -45,6 +45,39 @@ function pingMinecraftPE(host, port, timeout, callback) {
 		}
 	}, timeout);
 }
+// Allows MineTrack to ping Legacy Servers with the use of the MineQuery Plugin
+function pingMineQuery(host, port, timeout, callback) {
+
+
+	var s = require('net').Socket();
+	let parts = host.split(":")
+	s.connect(parts[1], parts[0]);
+	s.write('QUERY_JSON\n\r');
+
+	s.on('data', function (d) {
+		try {
+			response = JSON.parse(d.toString())
+
+			callback("", {
+				players: {
+					online: parseInt(response.playerCount),
+					max: parseInt("100")
+				},
+				version: 0,
+				latency: parseInt(100)
+			});
+		} catch (err) {
+			console.log(err)
+		}
+
+	});
+
+	s.on('error', function (err) {
+		console.log("Error: " + err.message);
+	})
+	s.end();
+
+}
 
 exports.ping = function(host, port, type, timeout, callback, version) {
 	if (type === 'PC') {
@@ -53,6 +86,8 @@ exports.ping = function(host, port, type, timeout, callback, version) {
 		})
 	} else if (type === 'PE') {
 		pingMinecraftPE(host, port || 19132, timeout, callback);
+	} else if (type === 'MINEQUERY') {
+		pingMineQuery(host, port || 19132, timeout, callback);
 	} else {
 		throw new Error('Unsupported type: ' + type);
 	}


### PR DESCRIPTION
Add Support for MineQuery Servers. MineQuery is useful for prerelease servers that run Beta and Alpha versions of the game.