### PR TITLE
Dynamic history graph player-count axis scaling

### DIFF
--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -2,6 +2,32 @@ import { formatNumber, formatTimestamp, isMobileBrowser } from './util'
 
 import { FAVORITE_SERVERS_STORAGE_KEY } from './favorites'
 
+// History graph player-count axis tick generator
+
+const historyTickCount = 21
+const divisionCount = 4 // e.g. 100 -> 25, 50, 75, 100
+// Maximum order of magnitude of divisions
+const maxOrder = 5
+
+function roundToDivision (count) {
+  const magnitude = Math.pow(10, Math.ceil(Math.min(Math.log10(count), maxOrder)))
+  const division = magnitude / divisionCount
+
+  // Round count to nearest division
+  return Math.ceil(count / division) * division
+}
+
+function historyGraphTickGenerator (axis) {
+  const result = []
+  const countPerTick = roundToDivision(axis.max) / (historyTickCount - 1)
+
+  for (let i = 0; i < historyTickCount; i++) {
+    result.push(countPerTick * i)
+  }
+
+  return result
+}
+
 export const HISTORY_GRAPH_OPTIONS = {
   series: {
     shadowSize: 0
@@ -14,7 +40,7 @@ export const HISTORY_GRAPH_OPTIONS = {
   },
   yaxis: {
     show: true,
-    tickSize: 5000,
+    ticks: historyGraphTickGenerator,
     tickLength: 10,
     tickFormatter: formatNumber,
     font: {


### PR DESCRIPTION
A quick analysis of server player counts over the last 24 hours (data from May 1st, 2020) yields the following:

| ID | Mean  | SD    | CV          |
|----|-------|-------|-------------|
| 1  | 215   | 50    | 0.23255814  |
| 2  | 433   | 330   | 0.762124711 |
| 3  | 491   | 375   | 0.763747454 |
| 4  | 1383  | 310   | 0.224150398 |
| 5  | 1805  | 295   | 0.163434903 |
| 6  | 2282  | 1653  | 0.724364592 |
| 7  | 2790  | 1077  | 0.386021505 |
| 8  | 2858  | 857   | 0.299860042 |
| 9  | 4191  | 2016  | 0.48103078  |
| 10 | 5823  | 4208  | 0.722651554 |
| 11 | 5863  | 4642  | 0.791744841 |
| 12 | 75316 | 13447 | 0.17854108  |

![CV(Player count over 24 hours)](https://i.hugmanrique.me/v2/ENfoO3UryR.png)

IDs are anonymized servers (you can probably figure out some of them ¯\\_(ツ)_/¯).

Even though the sample size is relatively small, observe that the standard deviation is independent of the average player count. This allows us to estimate the expected maximum player count by finding the highest player count of any server in the last 24 hours. A more correct approach would be to assume a normal distribution and compute `𝜇 + z𝜎` for a given z-score for each server, but it would require more computation.

I don't expect any server to get more than 200,000 players any time soon, so I [played on Desmos](https://www.desmos.com/calculator/zzhtscl9lt) and created the PR'd function. It basically gets the ceil of the order of magnitude of x (e.g. `x = 88_763 => 100_000`) and then divides it up into `divPerOrder` intervals, selecting the closest value greater than x. Here's some values (remember `x` is the _highest_ count):

| `x`    | `t(x)` |
|--------|--------|
| 30     | 50     |
| 170    | 250    |
| 320    | 500    |
| 2860   | 5000   |
| 88763  | 100000 |
| 102000 | 125000 |

Given current player counts, `t(x)` will almost always be 100,000; sometimes reaching 125,000.

Edit:
I was working on this while flot's auto scaling feature got enabled in the last commit. Improvements include maintaining 0 as the graph's minimum value and "rounder" values.

Re-"fixes" #158