### PR TITLE
Revert Hive IP

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -28,7 +28,7 @@
 	},
 	{
 		"name": "Hive Games",
-		"ip": "geo.hivebedrock.network",
+		"ip": "hivebedrock.network",
 		"type": "PE",
 		"color": "#ffcb03",
 		"favicon": "hive.png"


### PR DESCRIPTION
This issue is clearly on (our) Hive side of things, as it can be replicated outside of Minetrack and NodeJS.