### PR TITLE
5.5.3 release preview

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+**5.5.3** *(June 13 2020)*
+- Fixed issue with graph scales being wrongly set which could cause Y axis labels to not appear.
+- Updated uPlot dependency 1.0.8 -> 1.0.11.
+
 **5.5.2** *(June 12 2020)*
 - Fixed ping errors causing server graphs (or the historical graph) to sometimes disappear.
 - Fixed ping errors causing server graphs to reset their Y scale minimum to 0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "minetrack",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minetrack",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "A Minecraft server tracker that lets you focus on the basics.",
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
**5.5.3** *(June 13 2020)*
- Fixed issue with graph scales being wrongly set which could cause Y axis labels to not appear.
- ~Updated uPlot dependency 1.0.8 -> 1.0.11.~