### PR TITLE
5.5.8 release preview

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+**5.5.8** *(August 1 2020)*
+- Adds daily database copies. This is mostly for use by Minetrack Data for automated exports. By setting `createDailyDatabaseCopy: true` in `config.json`, Minetrack will lazily create a copy of `database.sql` for each day, automatically rolling over to a new file each day. The database file is named in the format of `database_copy_(day)-(month)-(year).sql`. Daily database copies do not contain indexes or previous records. Pings are inserted into the daily database copy as they occur, Minetrack will not retroactively insert previous pings from `database.sql`.
+-  Bump lodash from 4.17.15 to 4.17.19
+
 **5.5.7** *(July 7 2020)*
 - Fixes an issue in which the light theme CSS may not be applied by default.
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -1,11 +1,38 @@
 const sqlite = require('sqlite3')
 
+const config = require('../config')
 const { TimeTracker } = require('./time')
 
 class Database {
   constructor (app) {
     this._app = app
     this._sql = new sqlite.Database('database.sql')
+  }
+
+  getDailyDatabase () {
+    if (!config.createDailyDatabaseCopy) {
+      return
+    }
+
+    const date = new Date()
+    const fileName = `database_copy_${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}.sql`
+
+    if (fileName !== this._currentDatabaseCopyFileName) {
+      if (this._currentDatabaseCopyInstance) {
+        this._currentDatabaseCopyInstance.close()
+      }
+
+      this._currentDatabaseCopyInstance = new sqlite.Database(fileName)
+      this._currentDatabaseCopyFileName = fileName
+
+      // Ensure the initial tables are created
+      // This does not created indexes since it is only inserted to
+      this._currentDatabaseCopyInstance.serialize(() => {
+        this._currentDatabaseCopyInstance.run('CREATE TABLE IF NOT EXISTS pings (timestamp BIGINT NOT NULL, ip TINYTEXT, playerCount MEDIUMINT)')
+      })
+    }
+
+    return this._currentDatabaseCopyInstance
   }
 
   ensureIndexes () {
@@ -122,7 +149,18 @@ class Database {
   }
 
   insertPing (ip, timestamp, unsafePlayerCount) {
-    const statement = this._sql.prepare('INSERT INTO pings (timestamp, ip, playerCount) VALUES (?, ?, ?)')
+    this._insertPingTo(ip, timestamp, unsafePlayerCount, this._sql)
+
+    // Push a copy of the data into the database copy, if any
+    // This creates an "insert only" copy of the database for archiving
+    const dailyDatabase = this.getDailyDatabase()
+    if (dailyDatabase) {
+      this._insertPingTo(ip, timestamp, unsafePlayerCount, dailyDatabase)
+    }
+  }
+
+  _insertPingTo (ip, timestamp, unsafePlayerCount, db) {
+    const statement = db.prepare('INSERT INTO pings (timestamp, ip, playerCount) VALUES (?, ?, ?)')
     statement.run(timestamp, ip, unsafePlayerCount)
     statement.finalize()
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "minetrack",
-  "version": "5.5.7",
+  "version": "5.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minetrack",
-  "version": "5.5.7",
+  "version": "5.5.8",
   "description": "A Minecraft server tracker that lets you focus on the basics.",
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
**5.5.8** *(August 1 2020)*
- Adds daily database copies. This is mostly for use by Minetrack Data for automated exports. By setting `createDailyDatabaseCopy: true` in `config.json`, Minetrack will lazily create a copy of `database.sql` for each day, automatically rolling over to a new file each day. The database file is named in the format of `database_copy_(day)-(month)-(year).sql`. Daily database copies do not contain indexes or previous records. Pings are inserted into the daily database copy as they occur, Minetrack will not retroactively insert previous pings from `database.sql`.
-  Bump lodash from 4.17.15 to 4.17.19