### PR TITLE
dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "daily"
+    time: "12:00"
+  assignees:
+    - "Cryptkeeper"
+    - "hugmanrique"
+  reviewers:
+    - "Cryptkeeper"
+    - "hugmanrique"
+  commit-message:
+    prefix: "npm"
+    include: "scope"


### PR DESCRIPTION
This adds a Dependabot configuration that creates pull requests on dependency updates and also notifies (non-public) about security vulnerabilities. I just tested it on my fork and it might be a good idea to check its reports.

The relevant features that have to be enabled for the repository can be found in: Settings > Security and analysis