### PR TITLE
Ensure modules are bundled

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -27,7 +27,7 @@ class Server {
   }
 
   createHttpServer () {
-    const distServeStatic = serveStatic('dist/html/')
+    const distServeStatic = serveStatic('dist/')
     const faviconsServeStatic = serveStatic('favicons/')
 
     this._http = http.createServer((req, res) => {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,13 @@
   "engines": {
     "node": ">=12.4.0"
   },
+  "targets": {
+      "main": {
+          "engines": {
+              "browsers": "defaults"
+          }
+      }
+  },
   "devDependencies": {
     "@babel/core": "^7.10.2",
     "@babel/plugin-proposal-class-properties": "^7.10.1",


### PR DESCRIPTION
Engine needs to be explicitly specified for the default target, or else parcel will assume the context is node based on the engine, and not bundle the node modules.

Also changed the server to serve from `dist` again considering that is where parcel puts the output.

Should fix #238 