### PR TITLE
Added https://minetrack.geyserconnect.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ You can find a list of community hosted instances below. Want to be listed here?
 * https://stats.telfrancesco.it
 * https://suomimine.fi
 * https://minecraft-stats.de
+* https://minetrack.geyserconnect.net
 
 ## Updates
 For updates and release notes, please read the [CHANGELOG](docs/CHANGELOG.md).


### PR DESCRIPTION
This instance is explicitly for cross-play servers that support simultaneous play from Java and Bedrock clients by using the GeyserMC plugin.