### PR TITLE
Removed HiveMC from default servers.json

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -5,11 +5,6 @@
 		"type": "PC"
 	},
 	{
-		"name": "HiveMC",
-		"ip": "play.hivemc.com",
-		"type": "PC"
-	},
-	{
 		"name": "Mineplex",
 		"ip": "us.mineplex.com",
 		"type": "PC"


### PR DESCRIPTION
HiveMC for Java is closed. This PR removes it from default servers configuration.