### PR TITLE
Add minetrack.galaxite.dev to community list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can find a list of community hosted instances below. Want to be listed here?
 * https://minetrack.top
 * https://stats.liste-serveurs.fr
 * https://minetrack.live
+* https://minetrack.galaxite.dev/
 
 ## Updates
 For updates and release notes, please read the [CHANGELOG](docs/CHANGELOG.md).


### PR DESCRIPTION
<https://minetrack.galaxite.dev/> has been hosted for a year now and it's been up reliably for anyone else to access MCBE.