### PR TITLE
Bump Docker build to node 16 LTS (should fix docker build errors)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15
+FROM node:16
 
 ARG TINI_VER="v0.19.0"
 


### PR DESCRIPTION
While building docker image I'm getting

```
#9 [4/8] RUN apt-get update                                                    && apt-get install    --quiet --yes --no-install-recommends sqlite3  && apt-get clean      --quiet --yes                                  && apt-get autoremove --quiet --yes                                  && rm -rf /var/lib/apt/lists/*
#9 0.574 Ign:1 http://security.debian.org/debian-security stretch/updates InRelease
#9 0.585 Ign:2 http://deb.debian.org/debian stretch InRelease
#9 0.643 Ign:3 http://security.debian.org/debian-security stretch/updates Release
#9 0.657 Ign:4 http://deb.debian.org/debian stretch-updates InRelease
#9 0.725 Ign:5 http://deb.debian.org/debian stretch Release
#9 0.742 Ign:6 http://security.debian.org/debian-security stretch/updates/main all Packages
#9 0.791 Ign:7 http://deb.debian.org/debian stretch-updates Release
#9 0.818 Ign:8 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
#9 0.867 Ign:9 http://deb.debian.org/debian stretch/main amd64 Packages
#9 0.901 Ign:6 http://security.debian.org/debian-security stretch/updates/main all Packages
#9 0.929 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#9 0.981 Ign:8 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
#9 1.002 Ign:11 http://deb.debian.org/debian stretch-updates/main all Packages
#9 1.083 Ign:12 http://deb.debian.org/debian stretch-updates/main amd64 Packages
#9 1.148 Ign:6 http://security.debian.org/debian-security stretch/updates/main all Packages
#9 1.166 Ign:9 http://deb.debian.org/debian stretch/main amd64 Packages
#9 1.218 Ign:8 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
#9 1.237 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#9 1.305 Ign:11 http://deb.debian.org/debian stretch-updates/main all Packages
#9 1.313 Ign:6 http://security.debian.org/debian-security stretch/updates/main all Packages
#9 1.385 Ign:12 http://deb.debian.org/debian stretch-updates/main amd64 Packages
#9 1.390 Ign:8 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
#9 1.463 Ign:6 http://security.debian.org/debian-security stretch/updates/main all Packages
#9 1.471 Ign:9 http://deb.debian.org/debian stretch/main amd64 Packages
#9 1.536 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#9 1.540 Ign:8 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
#9 1.609 Ign:11 http://deb.debian.org/debian stretch-updates/main all Packages
#9 1.616 Ign:6 http://security.debian.org/debian-security stretch/updates/main all Packages
#9 1.691 Ign:12 http://deb.debian.org/debian stretch-updates/main amd64 Packages
#9 1.695 Err:8 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
#9 1.695   404  Not Found
#9 1.770 Ign:9 http://deb.debian.org/debian stretch/main amd64 Packages
#9 1.844 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#9 1.916 Ign:11 http://deb.debian.org/debian stretch-updates/main all Packages
#9 1.999 Ign:12 http://deb.debian.org/debian stretch-updates/main amd64 Packages
#9 2.085 Ign:9 http://deb.debian.org/debian stretch/main amd64 Packages
#9 2.148 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#9 2.205 Ign:11 http://deb.debian.org/debian stretch-updates/main all Packages
#9 2.284 Ign:12 http://deb.debian.org/debian stretch-updates/main amd64 Packages
#9 2.363 Err:9 http://deb.debian.org/debian stretch/main amd64 Packages
#9 2.363   404  Not Found
#9 2.436 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#9 2.510 Ign:11 http://deb.debian.org/debian stretch-updates/main all Packages
#9 2.591 Err:12 http://deb.debian.org/debian stretch-updates/main amd64 Packages
#9 2.591   404  Not Found
#9 2.594 Reading package lists...
#9 2.602 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
#9 2.602 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
#9 2.602 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
#9 2.602 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found
#9 2.602 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
#9 2.602 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
#9 2.602 E: Some index files failed to download. They have been ignored, or old ones used instead.
#9 ERROR: process "/bin/sh -c apt-get update                                                    && apt-get install    --quiet --yes --no-install-recommends sqlite3  && apt-get clean      --quiet --yes                                  && apt-get autoremove --quiet --yes                                  && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
------
 > [4/8] RUN apt-get update                                                    && apt-get install    --quiet --yes --no-install-recommends sqlite3  && apt-get clean      --quiet --yes                                  && apt-get autoremove --quiet --yes                                  && rm -rf /var/lib/apt/lists/*:
2.591 Err:12 http://deb.debian.org/debian stretch-updates/main amd64 Packages
2.591   404  Not Found
2.594 Reading package lists...
2.602 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
2.602 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
2.602 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
2.602 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found
2.602 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
2.602 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
2.602 E: Some index files failed to download. They have been ignored, or old ones used instead.
------
Dockerfile:10
--------------------
   9 |     # install sqlite3
  10 | >>> RUN apt-get update                                                   \
  11 | >>>  && apt-get install    --quiet --yes --no-install-recommends sqlite3 \
  12 | >>>  && apt-get clean      --quiet --yes                                 \
  13 | >>>  && apt-get autoremove --quiet --yes                                 \
  14 | >>>  && rm -rf /var/lib/apt/lists/*
  15 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update                                                    && apt-get install    --quiet --yes --no-install-recommends sqlite3  && apt-get clean      --quiet --yes                                  && apt-get autoremove --quiet --yes                                  && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100

View build details: docker-desktop://dashboard/build/default/default/p30ihf0jhamlfe4ham6z1670c
```

This should fix this and other build errors by building the image with the nearest node 15 LTS version.

Node 15 is unsupported and ended his cycle of life in 2021, the docker image was not updated since then, this could lead to obsolete build ambient.