### PR TITLE
Adding Minecraft Anarchy Servers Tracker to Community Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You can find a list of community hosted instances below. Want to be listed here?
 * https://suomimine.fi
 * https://minetrack.geyserconnect.net
 * https://minetrack.fi
+* https://www.anarchytrack.live/
 * https://track.axsoter.com
 * https://pvp-factions.fr
 * https://stats.liste-serveurs.fr


### PR DESCRIPTION
Added https://www.anarchytrack.live/ to Minetrack Community Showcase in the official repository